### PR TITLE
Updates resource to support Chef 13.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "ngqbao@gmail.com"
 license          "All rights reserved"
 description      "Manages nsswitch.conf"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -24,5 +24,5 @@ def initialize(*args)
   notifies :create, "template[/etc/nsswitch.conf]"
 end
 
-attribute :name, :kind_of => [String, NilClass], :name_attribute => true, :default => nil
+attribute :name, :kind_of => [String, NilClass], :name_attribute => true
 attribute :param,  :kind_of => [String],  :required => true


### PR DESCRIPTION
- Per https://docs.chef.io/deprecations_custom_resource_cleanups.html a property can no longer be specified as a 'name_property' *and* have a default definition.